### PR TITLE
ci: add requirements update workflow

### DIFF
--- a/.github/workflows/update-requirements.yml
+++ b/.github/workflows/update-requirements.yml
@@ -1,0 +1,57 @@
+name: Update requirements
+
+on:
+  workflow_dispatch:
+    inputs:
+      upgrade:
+        description: "Run uv pip compile with --upgrade"
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  compile-requirements:
+    name: Compile requirements.txt
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Compile requirements.txt
+        run: |
+          if [[ "${{ inputs.upgrade }}" == "true" ]]; then
+            uv pip compile requirements.in -o requirements.txt --upgrade
+          else
+            uv pip compile requirements.in -o requirements.txt
+          fi
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v8
+        with:
+          commit-message: "chore: update compiled requirements"
+          title: "chore: update compiled requirements"
+          body: |
+            This PR updates `requirements.txt` by running:
+
+            ```sh
+            uv pip compile requirements.in -o requirements.txt${{ inputs.upgrade && ' --upgrade' || '' }}
+            ```
+
+            The workflow only opens or updates this PR when the compiled output changes.
+          branch: chore/update-compiled-requirements
+          delete-branch: true


### PR DESCRIPTION
### Motivation
- Provide a manual GitHub Actions workflow to (re)compile `requirements.txt` from `requirements.in` using `uv pip compile` so compiled dependencies can be kept up-to-date. 
- Allow an optional `--upgrade` run and automatically open or update a PR only when the compiled output changes so maintainers can review dependency updates.

### Description
- Add `.github/workflows/update-requirements.yml` which is triggered by `workflow_dispatch` and exposes a boolean `upgrade` input. 
- Grant `contents: write` and `pull-requests: write` permissions and run steps using `actions/checkout@v6`, `actions/setup-python@v6` (Python 3.12), and `astral-sh/setup-uv@v7` with caching. 
- Run `uv pip compile requirements.in -o requirements.txt` and pass `--upgrade` when `upgrade` is `true`. 
- Use `peter-evans/create-pull-request@v8` to commit changes and open/update a PR on branch `chore/update-compiled-requirements`, deleting the branch after merge.

### Testing
- Successfully parsed the workflow YAML with `ruby -e 'require "yaml"; YAML.load_file(ARGV[0]); puts "YAML parsed successfully"' .github/workflows/update-requirements.yml`. 
- Verified the new file contents with `git diff --no-index --check -- /dev/null .github/workflows/update-requirements.yml`. 
- Attempted to run `go install github.com/rhysd/actionlint/cmd/actionlint@latest` for `actionlint` validation but the Go proxy returned `Forbidden` in this environment, so `actionlint` validation was not completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2922dbf91c832dbb9e18e048215ffe)