### PR TITLE
Schedule weekly requirements update and open PR instead of pushing to main

### DIFF
--- a/.github/workflows/update-requirements.yml
+++ b/.github/workflows/update-requirements.yml
@@ -1,21 +1,22 @@
 name: Update requirements
 
 on:
+  schedule:
+    # Every Monday at 00:00 UTC. The workflow opens a PR instead of pushing to main.
+    - cron: "0 0 * * 1"
   workflow_dispatch:
-    inputs:
-      upgrade:
-        description: "Run uv pip compile with --upgrade"
-        required: false
-        type: boolean
-        default: false
 
 permissions:
   contents: write
   pull-requests: write
 
+concurrency:
+  group: update-requirements
+  cancel-in-progress: true
+
 jobs:
   compile-requirements:
-    name: Compile requirements.txt
+    name: Update requirements.txt
     runs-on: ubuntu-latest
 
     steps:
@@ -32,13 +33,8 @@ jobs:
         with:
           enable-cache: true
 
-      - name: Compile requirements.txt
-        run: |
-          if [[ "${{ inputs.upgrade }}" == "true" ]]; then
-            uv pip compile requirements.in -o requirements.txt --upgrade
-          else
-            uv pip compile requirements.in -o requirements.txt
-          fi
+      - name: Upgrade and compile requirements.txt
+        run: uv pip compile requirements.in -o requirements.txt --upgrade
 
       # Use a PAT/App token when the repository setting blocks GITHUB_TOKEN from
       # creating pull requests. If CREATE_PULL_REQUEST_TOKEN is not configured,
@@ -51,12 +47,12 @@ jobs:
           commit-message: "chore: update compiled requirements"
           title: "chore: update compiled requirements"
           body: |
-            This PR updates `requirements.txt` by running:
+            This PR updates `requirements.txt` from `requirements.in` by running:
 
             ```sh
-            uv pip compile requirements.in -o requirements.txt${{ inputs.upgrade && ' --upgrade' || '' }}
+            uv pip compile requirements.in -o requirements.txt --upgrade
             ```
 
-            The workflow only opens or updates this PR when the compiled output changes.
+            The workflow runs weekly and only opens or updates this PR when the compiled output changes.
           branch: chore/update-compiled-requirements
           delete-branch: true


### PR DESCRIPTION
### Motivation

- The existing workflow should automatically refresh `requirements.txt` from `requirements.in` on a regular cadence and avoid pushing changes directly to `main`. 
- The update job must avoid overlapping runs and provide a PR-based review flow instead of auto-merging compiled changes.

### Description

- Add a `schedule` trigger with `cron: "0 0 * * 1"` so the workflow runs weekly on Monday 00:00 UTC while keeping `workflow_dispatch` for manual runs. 
- Add `concurrency` with `group: update-requirements` and `cancel-in-progress: true` to prevent overlapping workflow executions. 
- Replace the conditional compile step with a stable upgrade-and-compile command `uv pip compile requirements.in -o requirements.txt --upgrade`. 
- Create or update a PR using `peter-evans/create-pull-request@v8` on branch `chore/update-compiled-requirements` so changes are opened as a PR and not applied directly to `main`.

### Testing

- Ran a Python content check script that verified presence of `schedule`, the `cron` entry, `workflow_dispatch`, `--upgrade`, and the PR action, which passed. 
- Parsed the workflow YAML using `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/update-requirements.yml")'`, which succeeded. 
- Ran `git diff --check` and `git status` checks to validate the working tree, which reported no problems. 
- A PyYAML-based YAML parse was skipped because `PyYAML` was not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5edac85cf4832d884375bf9abb4b53)